### PR TITLE
DDCYLS-3134 Adjust submission audit position for use in exception cases

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,11 +1,11 @@
-import sbt._
+import sbt.*
 
 object AppDependencies {
-  import play.core.PlayVersion
+  val bootstrapVersion = "7.15.0"
 
-  val compile = Seq(
+  val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"     % "7.15.0",
+    "uk.gov.hmrc"       %% "bootstrap-frontend-play-28"     % bootstrapVersion,
     "uk.gov.hmrc"       %% "domain"                         % "8.3.0-play-28",
     "uk.gov.hmrc"       %% "emailaddress"                   % "3.8.0",
     "uk.gov.hmrc"       %% "play-frontend-hmrc"             % "7.7.0-play-28",
@@ -15,21 +15,17 @@ object AppDependencies {
     "uk.gov.hmrc"       %% "tax-year"                       % "3.2.0"
   )
 
-  val test = Seq(
-    "org.scalatest"           %% "scalatest"               % "3.2.10",
-    "org.scalatestplus"       %% "scalacheck-1-15"         % "3.2.10.0",
-    "org.scalatestplus"       %% "mockito-3-4"             % "3.2.10.0",
-    "org.scalatestplus.play"  %% "scalatestplus-play"      % "5.1.0",
-    "org.scalamock"           %% "scalamock"               % "5.1.0",
-    "org.pegdown"             %  "pegdown"                 % "1.6.0",
-    "org.jsoup"               %  "jsoup"                   % "1.14.3",
-    "com.typesafe.play"       %% "play-test"               % PlayVersion.current,
-    "org.mockito"             %% "mockito-scala"           % "1.16.42",
-    "org.scalacheck"          %% "scalacheck"              % "1.15.4",
-    "com.github.chocpanda"    %% "scalacheck-magnolia"     % "0.5.1",
-    "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-28" % "1.2.0",
-    "com.vladsch.flexmark"    %  "flexmark-all"            % "0.62.2",
-    "com.github.tomakehurst"  %  "wiremock-standalone"        % "2.27.2"
+  val test: Seq[ModuleID] = Seq(
+    "uk.gov.hmrc" %% "bootstrap-test-play-28" % bootstrapVersion,
+    "org.scalatestplus" %% "scalacheck-1-15" % "3.2.10.0",
+    "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0",
+    "org.scalamock" %% "scalamock" % "5.1.0",
+    "org.jsoup" % "jsoup" % "1.14.3",
+    "org.mockito" %% "mockito-scala" % "1.16.42",
+    "com.github.chocpanda" %% "scalacheck-magnolia" % "0.5.1",
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-28" % "1.2.0",
+    "com.vladsch.flexmark" % "flexmark-all" % "0.62.2",
+    "com.github.tomakehurst" % "wiremock-standalone" % "2.27.2"
   ).map(_ % "test, it")
 
   def apply(): Seq[ModuleID] = compile ++ test


### PR DESCRIPTION
Currently these audits won't fire if there's an error sending the submission data to the backend and this means we're unable to troubleshoot issues as the data is not audited anywhere else.