### PR TITLE
DDCYLS-3376

### DIFF
--- a/app/forms/notification/LetterReferenceFormProvider.scala
+++ b/app/forms/notification/LetterReferenceFormProvider.scala
@@ -23,7 +23,7 @@ import play.api.data.Form
 
 class LetterReferenceFormProvider @Inject() extends Mappings {
 
-  val formatRegex: String = "(?i)CFS[Ss|Cc]?[\\s]?[-]?[0-9]{7}\\.?$"
+  val formatRegex: String = "(?i)CFS[Ss|Cc]?[\\s]?[-]?[0-9]{7,8}\\.?$"
 
   def apply(): Form[String] =
     Form(

--- a/app/forms/reference/WhatIsTheCaseReferenceFormProvider.scala
+++ b/app/forms/reference/WhatIsTheCaseReferenceFormProvider.scala
@@ -23,7 +23,7 @@ import play.api.data.Form
 
 class WhatIsTheCaseReferenceFormProvider @Inject() extends Mappings {
 
-  val formatRegex: String = "(?i)CFS[Ss|Cc]?[\\s]?[-]?[0-9]{7}\\.?$"
+  val formatRegex: String = "(?i)CFS[Ss|Cc]?[\\s]?[-]?[0-9]{7,8}\\.?$"
 
   def apply(): Form[String] =
     Form(

--- a/test-utils/generators/CaseReferenceGenerators.scala
+++ b/test-utils/generators/CaseReferenceGenerators.scala
@@ -22,10 +22,10 @@ import org.scalacheck.Gen.{listOfN, numChar}
 
 trait CaseReferenceGenerators {
 
-  val numberOfDigitsReferenceNumber = 7
+  val numberOfDigitsReferenceNumber = 8
   val shortPrefix = "CFS"
   val longPrefix = "CFSS"
-  val caseReferenceFormatRegex = "(?i)CFS[Ss|Cc]?[\\s]?[-]?[0-9]{7}\\.?$"
+  val caseReferenceFormatRegex = "(?i)CFS[Ss|Cc]?[\\s]?[-]?[0-9]{7,8}\\.?$"
 
   def generateValidCaseReference(): Gen[String] = for {
     isWithLongPrefix <- arbitrary[Boolean]


### PR DESCRIPTION
- Letter reference form provider now allows a length of 8 
- Case reference form provider now allows a length of 8 
- Case reference generator used by both providers above now generates upto a length of 8