### PR TITLE
DDCYLS-4410 Added text validation for problematic Unicode chars

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -20,8 +20,8 @@ import com.google.inject.{Inject, Singleton}
 import play.api.Configuration
 import play.api.i18n.Lang
 import play.api.mvc.RequestHeader
-import uk.gov.hmrc.play.bootstrap.binders.SafeRedirectUrl
 
+import java.net.URLEncoder
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 @Singleton
@@ -33,8 +33,8 @@ class FrontendAppConfig @Inject() (configuration: Configuration) {
   private lazy val contactHost = configuration.get[String]("contact-frontend.host")
   private lazy val contactFormServiceIdentifier = "digital-disclosure-service-frontend"
 
-  def feedbackUrl(implicit request: RequestHeader): String =
-    s"$contactHost/contact/beta-feedback?service=$contactFormServiceIdentifier&backUrl=${SafeRedirectUrl(host + request.uri).encodedUrl}"
+  def feedbackUrl(implicit request: RequestHeader): String = s"$contactHost/contact/beta-feedback?service=" +
+    s"$contactFormServiceIdentifier&backUrl=${URLEncoder.encode(host + request.uri, "UTF-8")}"
 
   lazy val loginUrl: String         = configuration.get[String]("urls.login")
   lazy val loginContinueUrl: String = configuration.get[String]("urls.loginContinue")

--- a/app/forms/letting/PropertyIsNoLongerBeingLetOutFormProvider.scala
+++ b/app/forms/letting/PropertyIsNoLongerBeingLetOutFormProvider.scala
@@ -39,7 +39,9 @@ class PropertyIsNoLongerBeingLetOutFormProvider @Inject() extends Mappings {
         .verifying(maxDate(LocalDate.now().minusDays(1), "propertyIsNoLongerBeingLetOut.stopDate.error.invalidFutureDate")),
 
         "whatHasHappenedToProperty" -> text("propertyIsNoLongerBeingLetOut.whatHasHappenedToProperty.error.required")
-        .verifying(maxLength(5000, "propertyIsNoLongerBeingLetOut.whatHasHappenedToProperty.error.length"))
+          .verifying(maxLength(5000, "propertyIsNoLongerBeingLetOut.whatHasHappenedToProperty.error.length"))
+          .verifying(validUnicodeCharacters)
+
       )(NoLongerBeingLetOut.apply)(NoLongerBeingLetOut.unapply)
     )
 }

--- a/app/forms/letting/WhatWasTheTypeOfMortgageFormProvider.scala
+++ b/app/forms/letting/WhatWasTheTypeOfMortgageFormProvider.scala
@@ -27,5 +27,6 @@ class WhatWasTheTypeOfMortgageFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("whatWasTheTypeOfMortgage.error.required")
         .verifying(maxLength(500, "whatWasTheTypeOfMortgage.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -16,9 +16,11 @@
 
 package forms.mappings
 
+import forms.mappings.FormBindConstants.invalidUnicodeCharacters
+
 import java.time.LocalDate
 import uk.gov.hmrc.domain.Nino
-import play.api.data.validation.{Constraint, Invalid, Valid, ValidationResult, ValidationError}
+import play.api.data.validation.{Constraint, Invalid, Valid, ValidationError, ValidationResult}
 import uk.gov.hmrc.emailaddress.EmailAddress
 
 trait Constraints {
@@ -101,7 +103,7 @@ trait Constraints {
         Valid
       case _ =>
         Invalid(errorKey, args: _*)
-    }  
+    }
 
   protected def minLength(minimum: Int, errorKey: String): Constraint[String] =
     Constraint {
@@ -160,7 +162,7 @@ trait Constraints {
   private def checkValidNinoFormat(str: String): Boolean = {
     val pattern = "^[a-zA-Z]{2}\\d{6}[a-zA-Z]$"
     pattern.r.findFirstMatchIn(str.replaceAll("\\s", "")).isDefined
-  }  
+  }
 
   protected def validUTR(length: Int, errorKey: String): Constraint[String] =
     Constraint {
@@ -186,20 +188,23 @@ trait Constraints {
     }
   }
 
-  protected def validDigits(errorKey: String): Constraint[String] =
+  protected def allOrNoneCheckboxConstraint[A](errorKey: String, singleOption: A): Constraint[Set[A]] =
     Constraint {
-      case number if number.forall(_.isDigit) => Valid
-      case _ => Invalid(errorKey)
-    }
-
-  protected def allOrNoneCheckboxConstraint[A](errorKey: String, singleOption: A): Constraint[Set[A]] = 
-    Constraint { 
       s => {
         if (s.contains(singleOption) && s.size > 1) {
           Invalid(Seq(ValidationError(errorKey)))
         } else {
           Valid
         }
+      }
+    }
+
+  def validUnicodeCharacters: Constraint[String] =
+    Constraint { str =>
+      if (invalidUnicodeCharacters.exists(str.contains)) {
+        Invalid("error.invalidUnicodeChars")
+      } else {
+        Valid
       }
     }
 }

--- a/app/forms/mappings/FormBindConstants.scala
+++ b/app/forms/mappings/FormBindConstants.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,8 @@
  * limitations under the License.
  */
 
-package forms
+package forms.mappings
 
-import javax.inject.Inject
-
-import forms.mappings.Mappings
-import play.api.data.Form
-
-class AdviceBusinessNameFormProvider @Inject() extends Mappings {
-
-  def apply(): Form[String] =
-    Form(
-      "value" -> text("adviceBusinessName.error.required")
-        .verifying(maxLength(50, "adviceBusinessName.error.length"))
-        .verifying(validUnicodeCharacters)
-    )
+object FormBindConstants {
+  val invalidUnicodeCharacters: Seq[String] = Seq("\u0002", "\u001D")
 }

--- a/app/forms/notification/OtherIncomeOrGainSourceFormProvider.scala
+++ b/app/forms/notification/OtherIncomeOrGainSourceFormProvider.scala
@@ -27,5 +27,6 @@ class OtherIncomeOrGainSourceFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("whereDidTheUndeclaredIncomeOrGain.error.required")
         .verifying(maxLength(5000, "whereDidTheUndeclaredIncomeOrGain.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/notification/WhatIsTheIndividualOccupationFormProvider.scala
+++ b/app/forms/notification/WhatIsTheIndividualOccupationFormProvider.scala
@@ -27,5 +27,6 @@ class WhatIsTheIndividualOccupationFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("whatIsTheIndividualOccupation.error.required")
         .verifying(maxLength(30, "whatIsTheIndividualOccupation.error.maxLength"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/notification/WhatIsTheIndividualsFullNameFormProvider.scala
+++ b/app/forms/notification/WhatIsTheIndividualsFullNameFormProvider.scala
@@ -27,5 +27,6 @@ class WhatIsTheIndividualsFullNameFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("whatIsTheIndividualsFullName.error.required")
         .verifying(maxLength(30, "whatIsTheIndividualsFullName.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/notification/WhatIsTheLLPNameFormProvider.scala
+++ b/app/forms/notification/WhatIsTheLLPNameFormProvider.scala
@@ -27,5 +27,6 @@ class WhatIsTheLLPNameFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("whatIsTheLLPName.error.required")
         .verifying(maxLength(50, "whatIsTheLLPName.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/notification/WhatIsTheNameOfTheCompanyTheDisclosureWillBeAboutFormProvider.scala
+++ b/app/forms/notification/WhatIsTheNameOfTheCompanyTheDisclosureWillBeAboutFormProvider.scala
@@ -27,5 +27,6 @@ class WhatIsTheNameOfTheCompanyTheDisclosureWillBeAboutFormProvider @Inject() ex
     Form(
       "value" -> text("whatIsTheNameOfTheCompanyTheDisclosureWillBeAbout.error.required")
         .verifying(maxLength(50, "whatIsTheNameOfTheCompanyTheDisclosureWillBeAbout.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/notification/WhatIsTheNameOfTheOrganisationYouRepresentFormProvider.scala
+++ b/app/forms/notification/WhatIsTheNameOfTheOrganisationYouRepresentFormProvider.scala
@@ -27,5 +27,6 @@ class WhatIsTheNameOfTheOrganisationYouRepresentFormProvider @Inject() extends M
     Form(
       "value" -> text("whatIsTheNameOfTheOrganisationYouRepresent.error.required")
         .verifying(maxLength(50, "whatIsTheNameOfTheOrganisationYouRepresent.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/notification/WhatIsThePersonOccupationFormProvider.scala
+++ b/app/forms/notification/WhatIsThePersonOccupationFormProvider.scala
@@ -27,5 +27,6 @@ class WhatWasThePersonOccupationFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("whatWasThePersonOccupation.error.required")
         .verifying(maxLength(30, "whatWasThePersonOccupation.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/notification/WhatIsTheTrustNameFormProvider.scala
+++ b/app/forms/notification/WhatIsTheTrustNameFormProvider.scala
@@ -27,5 +27,6 @@ class WhatIsTheTrustNameFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("whatIsTheTrustName.error.required")
         .verifying(maxLength(50, "whatIsTheTrustName.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/notification/WhatIsYourFullNameFormProvider.scala
+++ b/app/forms/notification/WhatIsYourFullNameFormProvider.scala
@@ -27,5 +27,6 @@ class WhatIsYourFullNameFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("whatIsYourFullName.error.required")
         .verifying(maxLength(30, "whatIsYourFullName.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/notification/WhatIsYourMainOccupationFormProvider.scala
+++ b/app/forms/notification/WhatIsYourMainOccupationFormProvider.scala
@@ -27,5 +27,6 @@ class WhatIsYourMainOccupationFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("whatIsYourMainOccupation.error.required")
         .verifying(maxLength(30, "whatIsYourMainOccupation.error.maxLength"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/notification/WhatWasTheNameOfThePersonWhoDiedFormProvider.scala
+++ b/app/forms/notification/WhatWasTheNameOfThePersonWhoDiedFormProvider.scala
@@ -27,5 +27,6 @@ class WhatWasTheNameOfThePersonWhoDiedFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("whatWasTheNameOfThePersonWhoDied.error.required")
         .verifying(maxLength(50, "whatWasTheNameOfThePersonWhoDied.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/offshore/TaxBeforeFiveYearsFormProvider.scala
+++ b/app/forms/offshore/TaxBeforeFiveYearsFormProvider.scala
@@ -27,5 +27,6 @@ class TaxBeforeFiveYearsFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("taxBeforeFiveYears.error.required", Seq(year))
         .verifying(maxLength(5000, "taxBeforeFiveYears.error.length"))
+        .verifying(validUnicodeCharacters)
     )
  }

--- a/app/forms/offshore/TaxBeforeNineteenYearsFormProvider.scala
+++ b/app/forms/offshore/TaxBeforeNineteenYearsFormProvider.scala
@@ -27,5 +27,6 @@ class TaxBeforeNineteenYearsFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("taxBeforeNineteenYears.error.required", Seq(year))
         .verifying(maxLength(5000, "taxBeforeNineteenYears.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/offshore/TaxBeforeSevenYearsFormProvider.scala
+++ b/app/forms/offshore/TaxBeforeSevenYearsFormProvider.scala
@@ -27,5 +27,6 @@ class TaxBeforeSevenYearsFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("taxBeforeSevenYears.error.required", Seq(year))
         .verifying(maxLength(5000, "taxBeforeSevenYears.error.length"))
+        .verifying(validUnicodeCharacters)
     )
  }

--- a/app/forms/offshore/TaxYearLiabilitiesFormProvider.scala
+++ b/app/forms/offshore/TaxYearLiabilitiesFormProvider.scala
@@ -60,7 +60,8 @@ class TaxYearLiabilitiesFormProvider @Inject() extends Mappings {
         "taxYearLiabilities.penaltyRate.error.nonNumeric")
           .verifying(inRange(BigDecimal(0.00), BigDecimal(200.00), "taxYearLiabilities.penaltyRate.error.outOfRange")),
       "penaltyRateReason" -> text("taxYearLiabilities.penaltyRateReason.error.required")
-        .verifying(maxLength(MAX_TEXT_BOX_SIZE, "taxYearLiabilities.penaltyRateReason.error.length")),
+        .verifying(maxLength(MAX_TEXT_BOX_SIZE, "taxYearLiabilities.penaltyRateReason.error.length"))
+        .verifying(validUnicodeCharacters),
       "undeclaredIncomeOrGain" -> stringOptionalUnless("undeclaredIncomeOrGain"),
 
   "foreignTaxCredit" -> boolean("taxYearLiabilities.foreignTaxCredit.error.required")
@@ -72,6 +73,7 @@ class TaxYearLiabilitiesFormProvider @Inject() extends Mappings {
     optional(
       text(s"taxYearLiabilities.$field.error.required")
         .verifying(maxLength(MAX_TEXT_BOX_SIZE, "taxYearLiabilities.undeclaredIncomeOrGain.error.length"))
+        .verifying(validUnicodeCharacters)
     )
       .verifying(optionalUnless(true, s"taxYearLiabilities.$field.error.required"))
   }

--- a/app/forms/offshore/UnderWhatConsiderationFormProvider.scala
+++ b/app/forms/offshore/UnderWhatConsiderationFormProvider.scala
@@ -27,5 +27,6 @@ class UnderWhatConsiderationFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("underWhatConsideration.error.required")
         .verifying(maxLength(5000, "underWhatConsideration.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/offshore/WhatIsYourReasonableExcuseForNotFilingReturnFormProvider.scala
+++ b/app/forms/offshore/WhatIsYourReasonableExcuseForNotFilingReturnFormProvider.scala
@@ -30,16 +30,18 @@ class WhatIsYourReasonableExcuseForNotFilingReturnFormProvider @Inject() extends
       "reasonableExcuse" -> text("whatIsYourReasonableExcuseForNotFilingReturn.error.reasonableExcuse.required")
         .verifying(
           maxLength(
-            5000, 
+            5000,
             if(areTheyTheIndividual) {
               "whatIsYourReasonableExcuseForNotFilingReturn.entity.error.reasonableExcuse.length"
             } else {
               "whatIsYourReasonableExcuseForNotFilingReturn.agent.error.reasonableExcuse.length"
             }
           )
-        ),
+        )
+        .verifying(validUnicodeCharacters),
       "yearsThisAppliesTo" -> text("whatIsYourReasonableExcuseForNotFilingReturn.error.yearsThisAppliesTo.required")
         .verifying(maxLength(500, "whatIsYourReasonableExcuseForNotFilingReturn.error.yearsThisAppliesTo.length"))
+        .verifying(validUnicodeCharacters)
     )(WhatIsYourReasonableExcuseForNotFilingReturn.apply)(WhatIsYourReasonableExcuseForNotFilingReturn.unapply)
    )
  }

--- a/app/forms/offshore/WhatIsYourReasonableExcuseFormProvider.scala
+++ b/app/forms/offshore/WhatIsYourReasonableExcuseFormProvider.scala
@@ -30,16 +30,18 @@ class WhatIsYourReasonableExcuseFormProvider @Inject() extends Mappings {
       "excuse" -> text("whatIsYourReasonableExcuse.error.excuse.required")
         .verifying(
           maxLength(
-            5000, 
+            5000,
             if(areTheyTheIndividual) {
               "whatIsYourReasonableExcuse.entity.error.excuse.length"
             } else {
               "whatIsYourReasonableExcuse.agent.error.excuse.length"
             }
           )
-        ),
+        )
+        .verifying(validUnicodeCharacters),
       "years" -> text("whatIsYourReasonableExcuse.error.years.required")
         .verifying(maxLength(500, "whatIsYourReasonableExcuse.error.years.length"))
+        .verifying(validUnicodeCharacters)
     )(WhatIsYourReasonableExcuse.apply)(WhatIsYourReasonableExcuse.unapply)
    )
  }

--- a/app/forms/offshore/WhatReasonableCareDidYouTakeFormProvider.scala
+++ b/app/forms/offshore/WhatReasonableCareDidYouTakeFormProvider.scala
@@ -37,9 +37,11 @@ class WhatReasonableCareDidYouTakeFormProvider @Inject() extends Mappings {
               "whatReasonableCareDidYouTake.agent.error.reasonableCare.length"
             }
           )
-        ),
+        )
+        .verifying(validUnicodeCharacters),
       "yearsThisAppliesTo" -> text("whatReasonableCareDidYouTake.error.yearsThisAppliesTo.required")
         .verifying(maxLength(500, "whatReasonableCareDidYouTake.error.yearsThisAppliesTo.length"))
+        .verifying(validUnicodeCharacters)
     )(WhatReasonableCareDidYouTake.apply)(WhatReasonableCareDidYouTake.unapply)
    )
  }

--- a/app/forms/offshore/YouHaveLeftTheDDSFormProvider.scala
+++ b/app/forms/offshore/YouHaveLeftTheDDSFormProvider.scala
@@ -27,5 +27,6 @@ class YouHaveLeftTheDDSFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("youHaveLeftTheDDS.error.required")
         .verifying(maxLength(30, "youHaveLeftTheDDS.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/offshore/YouHaveNotIncludedTheTaxYearFormProvider.scala
+++ b/app/forms/offshore/YouHaveNotIncludedTheTaxYearFormProvider.scala
@@ -27,5 +27,6 @@ class YouHaveNotIncludedTheTaxYearFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("youHaveNotIncludedTheTaxYear.error.required", Seq(missingYear))
         .verifying(maxLength(500, "youHaveNotIncludedTheTaxYear.error.length", missingYear))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/offshore/YouHaveNotSelectedCertainTaxYearFormProvider.scala
+++ b/app/forms/offshore/YouHaveNotSelectedCertainTaxYearFormProvider.scala
@@ -27,5 +27,6 @@ class YouHaveNotSelectedCertainTaxYearFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("youHaveNotSelectedCertainTaxYear.error.required")
         .verifying(maxLength(500, "youHaveNotSelectedCertainTaxYear.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/onshore/CorporationTaxLiabilityFormProvider.scala
+++ b/app/forms/onshore/CorporationTaxLiabilityFormProvider.scala
@@ -70,7 +70,8 @@ class CorporationTaxLiabilityFormProvider @Inject() extends Mappings {
         .verifying(inRange(BigDecimal(0.00), BigDecimal(200.00), "corporationTaxLiability.penaltyRate.error.outOfRange")),
         
         "penaltyRateReason" -> text("corporationTaxLiability.penaltyRateReason.error.required")
-        .verifying(maxLength(5000, "corporationTaxLiability.penaltyRateReason.error.length"))
+          .verifying(maxLength(5000, "corporationTaxLiability.penaltyRateReason.error.length"))
+          .verifying(validUnicodeCharacters)
         
       )(CorporationTaxLiability.apply)(CorporationTaxLiability.unapply)
     )

--- a/app/forms/onshore/DirectorLoanAccountLiabilitiesFormProvider.scala
+++ b/app/forms/onshore/DirectorLoanAccountLiabilitiesFormProvider.scala
@@ -31,7 +31,8 @@ class DirectorLoanAccountLiabilitiesFormProvider @Inject() extends Mappings {
   def apply(): Form[DirectorLoanAccountLiabilities] = Form(
      mapping(
        "name" -> text("directorLoanAccountLiabilities.name.required")
-         .verifying(maxLength(30, "directorLoanAccountLiabilities.name.invalid")),
+         .verifying(maxLength(30, "directorLoanAccountLiabilities.name.invalid"))
+         .verifying(validUnicodeCharacters),
 
        "periodEnd" -> localDate(
          "directorLoanAccountLiabilities.periodEnd.error.invalid",
@@ -67,6 +68,7 @@ class DirectorLoanAccountLiabilitiesFormProvider @Inject() extends Mappings {
       
       "penaltyRateReason" -> text("directorLoanAccountLiabilities.penaltyRateReason.error.required")
         .verifying(maxLength(5000, "directorLoanAccountLiabilities.penaltyRateReason.error.length"))
+        .verifying(validUnicodeCharacters)
 
     )(DirectorLoanAccountLiabilities.apply)(DirectorLoanAccountLiabilities.unapply)
    )

--- a/app/forms/onshore/NotIncludedMultipleTaxYearsFormProvider.scala
+++ b/app/forms/onshore/NotIncludedMultipleTaxYearsFormProvider.scala
@@ -27,5 +27,6 @@ class NotIncludedMultipleTaxYearsFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("youHaveNotSelectedCertainTaxYear.error.required")
         .verifying(maxLength(500, "youHaveNotSelectedCertainTaxYear.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/onshore/NotIncludedSingleTaxYearFormProvider.scala
+++ b/app/forms/onshore/NotIncludedSingleTaxYearFormProvider.scala
@@ -27,5 +27,6 @@ class NotIncludedSingleTaxYearFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("youHaveNotIncludedTheTaxYear.error.required", Seq(missingYear))
         .verifying(maxLength(500, "youHaveNotIncludedTheTaxYear.error.length", missingYear))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/onshore/OnshoreTaxYearLiabilitiesFormProvider.scala
+++ b/app/forms/onshore/OnshoreTaxYearLiabilitiesFormProvider.scala
@@ -54,7 +54,8 @@ class OnshoreTaxYearLiabilitiesFormProvider @Inject() extends Mappings  {
         "onshoreTaxYearLiabilities.penaltyRate.error.nonNumeric")
           .verifying(inRange(BigDecimal(0.00), BigDecimal(200.00), "onshoreTaxYearLiabilities.penaltyRate.error.outOfRange")),
       "penaltyRateReason" -> text("onshoreTaxYearLiabilities.penaltyRateReason.error.required")
-        .verifying(maxLength(5000, "onshoreTaxYearLiabilities.penaltyRateReason.error.length")),
+        .verifying(maxLength(5000, "onshoreTaxYearLiabilities.penaltyRateReason.error.length"))
+        .verifying(validUnicodeCharacters),
       "undeclaredIncomeOrGain" -> stringOptionalUnless("undeclaredIncomeOrGain"),
       "residentialTaxReduction" -> optional(boolean("onshoreTaxYearLiabilities.residentialTaxReduction.error.required"))
         .verifying(optionalUnless(taxTypes.contains(WhatOnshoreLiabilitiesDoYouNeedToDisclose.LettingIncome), "onshoreTaxYearLiabilities.residentialTaxReduction.error.required"))
@@ -74,7 +75,8 @@ class OnshoreTaxYearLiabilitiesFormProvider @Inject() extends Mappings  {
   def stringOptionalUnless(field: String): Mapping[Option[String]] = {
     optional(
       text(s"onshoreTaxYearLiabilities.$field.error.required")
-      .verifying(maxLength(5000, "onshoreTaxYearLiabilities.undeclaredIncomeOrGain.error.length"))
+        .verifying(maxLength(5000, "onshoreTaxYearLiabilities.undeclaredIncomeOrGain.error.length"))
+        .verifying(validUnicodeCharacters)
     )
     .verifying(optionalUnless(true, s"onshoreTaxYearLiabilities.$field.error.required"))
   }

--- a/app/forms/onshore/ReasonableCareOnshoreFormProvider.scala
+++ b/app/forms/onshore/ReasonableCareOnshoreFormProvider.scala
@@ -37,9 +37,11 @@ class ReasonableCareOnshoreFormProvider @Inject() extends Mappings {
               "whatReasonableCareDidYouTake.agent.error.reasonableCare.length"
             }
           )
-        ),
+        )
+        .verifying(validUnicodeCharacters),
       "yearsThisAppliesTo" -> text("whatReasonableCareDidYouTake.error.yearsThisAppliesTo.required")
         .verifying(maxLength(500, "whatReasonableCareDidYouTake.error.yearsThisAppliesTo.length"))
+        .verifying(validUnicodeCharacters)
     )(ReasonableCareOnshore.apply)(ReasonableCareOnshore.unapply)
    )
  }

--- a/app/forms/onshore/ReasonableExcuseForNotFilingOnshoreFormProvider.scala
+++ b/app/forms/onshore/ReasonableExcuseForNotFilingOnshoreFormProvider.scala
@@ -30,16 +30,18 @@ class ReasonableExcuseForNotFilingOnshoreFormProvider @Inject() extends Mappings
       "reasonableExcuse" -> text("whatIsYourReasonableExcuseForNotFilingReturn.error.reasonableExcuse.required")
         .verifying(
           maxLength(
-            5000, 
+            5000,
             if(areTheyTheIndividual) {
               "whatIsYourReasonableExcuseForNotFilingReturn.entity.error.reasonableExcuse.length"
             } else {
               "whatIsYourReasonableExcuseForNotFilingReturn.agent.error.reasonableExcuse.length"
             }
           )
-        ),
+        )
+        .verifying(validUnicodeCharacters),
       "yearsThisAppliesTo" -> text("whatIsYourReasonableExcuseForNotFilingReturn.error.yearsThisAppliesTo.required")
         .verifying(maxLength(500, "whatIsYourReasonableExcuseForNotFilingReturn.error.yearsThisAppliesTo.length"))
+        .verifying(validUnicodeCharacters)
     )(ReasonableExcuseForNotFilingOnshore.apply)(ReasonableExcuseForNotFilingOnshore.unapply)
    )
  }

--- a/app/forms/onshore/ReasonableExcuseOnshoreFormProvider.scala
+++ b/app/forms/onshore/ReasonableExcuseOnshoreFormProvider.scala
@@ -30,16 +30,18 @@ class ReasonableExcuseOnshoreFormProvider @Inject() extends Mappings {
       "excuse" -> text("whatIsYourReasonableExcuse.error.excuse.required")
         .verifying(
           maxLength(
-            5000, 
+            5000,
             if(areTheyTheIndividual) {
               "whatIsYourReasonableExcuse.entity.error.excuse.length"
             } else {
               "whatIsYourReasonableExcuse.agent.error.excuse.length"
             }
           )
-        ),
+        )
+        .verifying(validUnicodeCharacters),
       "years" -> text("whatIsYourReasonableExcuse.error.years.required")
         .verifying(maxLength(500, "whatIsYourReasonableExcuse.error.years.length"))
+        .verifying(validUnicodeCharacters)
     )(ReasonableExcuseOnshore.apply)(ReasonableExcuseOnshore.unapply)
    )
  }

--- a/app/forms/onshore/TaxBeforeFiveYearsOnshoreFormProvider.scala
+++ b/app/forms/onshore/TaxBeforeFiveYearsOnshoreFormProvider.scala
@@ -27,5 +27,6 @@ class TaxBeforeFiveYearsOnshoreFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("taxBeforeFiveYears.error.required", Seq(year))
         .verifying(maxLength(5000, "taxBeforeFiveYears.error.length"))
+        .verifying(validUnicodeCharacters)
     )
  }

--- a/app/forms/onshore/TaxBeforeNineteenYearsOnshoreFormProvider.scala
+++ b/app/forms/onshore/TaxBeforeNineteenYearsOnshoreFormProvider.scala
@@ -27,5 +27,6 @@ class TaxBeforeNineteenYearsOnshoreFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("taxBeforeNineteenYears.error.required", Seq(year))
         .verifying(maxLength(5000, "taxBeforeNineteenYears.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/onshore/TaxBeforeThreeYearsOnshoreFormProvider.scala
+++ b/app/forms/onshore/TaxBeforeThreeYearsOnshoreFormProvider.scala
@@ -27,5 +27,6 @@ class TaxBeforeThreeYearsOnshoreFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("taxBeforeThreeYears.error.required", Seq(year))
         .verifying(maxLength(5000, "taxBeforeThreeYears.error.length"))
+        .verifying(validUnicodeCharacters)
     )
  }

--- a/app/forms/onshore/WhichLandlordAssociationsAreYouAMemberOfFormProvider.scala
+++ b/app/forms/onshore/WhichLandlordAssociationsAreYouAMemberOfFormProvider.scala
@@ -27,5 +27,6 @@ class WhichLandlordAssociationsAreYouAMemberOfFormProvider @Inject() extends Map
     Form(
       "value" -> text("whichLandlordAssociations.error.required")
         .verifying(maxLength(500, "whichLandlordAssociations.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/onshore/YouHaveLeftTheDDSOnshoreFormProvider.scala
+++ b/app/forms/onshore/YouHaveLeftTheDDSOnshoreFormProvider.scala
@@ -27,5 +27,6 @@ class YouHaveLeftTheDDSOnshoreFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("youHaveLeftTheDDS.error.required")
         .verifying(maxLength(30, "youHaveLeftTheDDS.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/otherLiabilities/DescribeTheGiftFormProvider.scala
+++ b/app/forms/otherLiabilities/DescribeTheGiftFormProvider.scala
@@ -27,5 +27,6 @@ class DescribeTheGiftFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("describeTheGift.error.required")
         .verifying(maxLength(5000, "describeTheGift.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/otherLiabilities/WhatOtherLiabilityIssuesFormProvider.scala
+++ b/app/forms/otherLiabilities/WhatOtherLiabilityIssuesFormProvider.scala
@@ -27,5 +27,6 @@ class WhatOtherLiabilityIssuesFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("whatOtherLiabilityIssues.error.required")
         .verifying(maxLength(5000, "whatOtherLiabilityIssues.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/reason/AdviceGivenFormProvider.scala
+++ b/app/forms/reason/AdviceGivenFormProvider.scala
@@ -28,16 +28,17 @@ class AdviceGivenFormProvider @Inject() extends Mappings {
    def apply(): Form[AdviceGiven] = Form(
      mapping(
       "adviceGiven" -> text("adviceGiven.error.adviceGiven.required")
-        .verifying(maxLength(5000, "adviceGiven.error.adviceGiven.length")),
+        .verifying(maxLength(5000, "adviceGiven.error.adviceGiven.length"))
+        .verifying(validUnicodeCharacters),
       "date" -> monthYear(
         invalidKey       = "adviceGiven.date.error.invalid",
         allRequiredKey   = "adviceGiven.date.error.required.all",
         requiredKey      = "adviceGiven.date.error.required",
         invalidMonthKey  = "adviceGiven.date.error.invalidMonth",
         futureDateKey = "adviceGiven.date.error.invalidFutureDate",
-        minimumDateKey = "adviceGiven.date.error.invalidPastDate" 
+        minimumDateKey = "adviceGiven.date.error.invalidPastDate"
       ),
-      "contact" -> enumerable[AdviceContactPreference]("adviceGiven.error.contact.required")  
+      "contact" -> enumerable[AdviceContactPreference]("adviceGiven.error.contact.required")
     )(AdviceGiven.apply)(AdviceGiven.unapply)
    )
  }

--- a/app/forms/reason/AdviceProfessionFormProvider.scala
+++ b/app/forms/reason/AdviceProfessionFormProvider.scala
@@ -28,5 +28,6 @@ class AdviceProfessionFormProvider @Inject() extends Mappings {
       "value" -> text("adviceProfession.error.required")
         .verifying(minLength(4, "adviceProfession.error.length"))
         .verifying(maxLength(30, "adviceProfession.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/reason/PersonWhoGaveAdviceFormProvider.scala
+++ b/app/forms/reason/PersonWhoGaveAdviceFormProvider.scala
@@ -27,5 +27,6 @@ class PersonWhoGaveAdviceFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("personWhoGaveAdvice.error.required")
         .verifying(maxLength(30, "personWhoGaveAdvice.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/reason/WhatIsTheReasonForMakingADisclosureNowFormProvider.scala
+++ b/app/forms/reason/WhatIsTheReasonForMakingADisclosureNowFormProvider.scala
@@ -27,5 +27,6 @@ class WhatIsTheReasonForMakingADisclosureNowFormProvider @Inject() extends Mappi
     Form(
       "value" -> text("whatIsTheReasonForMakingADisclosureNow.error.required")
         .verifying(maxLength(5000, "whatIsTheReasonForMakingADisclosureNow.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/app/forms/reason/WhyNotBeforeNowFormProvider.scala
+++ b/app/forms/reason/WhyNotBeforeNowFormProvider.scala
@@ -27,5 +27,6 @@ class WhyNotBeforeNowFormProvider @Inject() extends Mappings {
     Form(
       "value" -> text("whyNotBeforeNow.error.required")
         .verifying(maxLength(5000, "whyNotBeforeNow.error.length"))
+        .verifying(validUnicodeCharacters)
     )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -12,9 +12,9 @@ turnoffJSUglifyWarningsTask := Seq( "drop_console=true, warnings=false")
 lazy val root = (project in file("."))
   .enablePlugins(PlayScala, SbtAutoBuildPlugin, SbtDistributablesPlugin)
   .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
-  .settings(inConfig(Test)(testSettings): _*)
+  .settings(inConfig(Test)(testSettings) *)
   .configs(IntegrationTest)
-  .settings(inConfig(IntegrationTest)(itSettings): _*)
+  .settings(inConfig(IntegrationTest)(itSettings) *)
   .settings(majorVersion := 0)
   .settings(ThisBuild / useSuperShell := false)
   .settings(
@@ -73,7 +73,7 @@ lazy val root = (project in file("."))
   )
   .settings(uglifyCompressOptions := turnoffJSUglifyWarningsTask.value)
 
-lazy val testSettings: Seq[Def.Setting[_]] = Seq(
+lazy val testSettings: Seq[Def.Setting[?]] = Seq(
   fork := true,
   unmanagedSourceDirectories += baseDirectory.value / "test-utils",
   scalacOptions ++= Seq(

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -39,6 +39,7 @@ error.browser.title.prefix = Gwall:
 error.boolean = Rhowch ateb
 error.required = Nodwch werth
 error.summary.title = Mae problem wedi codi
+error.invalidUnicodeChars = Canfuwyd cymeriad Unicode annilys yn eich ymateb. Rhowch gynnig arall arni. Os gwnaethoch gopïo a gludo eich ymateb, ceisiwch ei deipio â llaw
 
 index.title = Rhowch wybod i CThEF am dreth sydd heb ei thalu o’r blynyddoedd blaenorol
 index.heading = Rhowch wybod i CThEF am dreth sydd heb ei thalu o’r blynyddoedd blaenorol

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -39,6 +39,7 @@ error.browser.title.prefix = Error:
 error.boolean = Please give an answer
 error.required = Please enter a value
 error.summary.title = There is a problem
+error.invalidUnicodeChars = An invalid Unicode character has been detected in your response. Please try again. If you copied and pasted your response, try entering it manually
 
 index.title = Tell HMRC about underpaid tax from previous years
 index.heading = Tell HMRC about underpaid tax from previous years

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,5 +1,3 @@
 # Add all the application routes to the app.routes file
 ->         /tell-hmrc-about-underpaid-tax-from-previous-years        app.Routes
 ->         /                                                         health.Routes
-
-GET        /admin/metrics             @com.kenshoo.play.metrics.MetricsController.metrics

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,8 +1,8 @@
 import sbt.*
 
 object AppDependencies {
-  val bootstrapVersion = "7.23.0"
-  val mongoVersion = "1.3.0"
+  val bootstrapVersion = "8.4.0"
+  val mongoVersion = "1.7.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
@@ -10,10 +10,9 @@ object AppDependencies {
     "uk.gov.hmrc"       %% "domain"                         % "8.3.0-play-28",
     "uk.gov.hmrc"       %% "emailaddress"                   % "3.8.0",
     "uk.gov.hmrc"       %% "play-frontend-hmrc"             % "7.29.0-play-28",
-    "uk.gov.hmrc"       %% "play-conditional-form-mapping"  % "1.13.0-play-28",
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"             % mongoVersion,
     "org.typelevel"     %% "cats-core"                      % "2.8.0",
-    "uk.gov.hmrc"       %% "tax-year"                       % "3.3.0"
+    "uk.gov.hmrc"       %% "tax-year"                       % "4.0.0"
   )
 
   val test: Seq[ModuleID] = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,11 +4,11 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.17.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.20")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.21")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 

--- a/test-utils/generators/Generators.scala
+++ b/test-utils/generators/Generators.scala
@@ -16,6 +16,8 @@
 
 package generators
 
+import forms.mappings.FormBindConstants.invalidUnicodeCharacters
+
 import java.time.{Instant, LocalDate, ZoneOffset}
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Gen._
@@ -159,7 +161,7 @@ trait Generators extends UserAnswersGenerator
 
   def stringsExcludingCRWithLengthBetween(minLength: Int, maxLength: Int): Gen[String] = for {
     length    <- Gen.chooseNum(minLength + 1, maxLength)
-    chars     <- listOfN(length, arbitrary[Char] suchThat (_ != '\r'))
+    chars     <- listOfN(length, arbitrary[Char] suchThat (char => char != '\r' && !invalidUnicodeCharacters.contains(char.toString)))
   } yield chars.mkString
 
   def stringsExceptSpecificValues(excluded: Seq[String]): Gen[String] =

--- a/test/forms/behaviours/StringFieldBehaviours.scala
+++ b/test/forms/behaviours/StringFieldBehaviours.scala
@@ -16,6 +16,7 @@
 
 package forms.behaviours
 
+import forms.mappings.FormBindConstants.invalidUnicodeCharacters
 import play.api.data.{Form, FormError}
 
 trait StringFieldBehaviours extends FieldBehaviours {
@@ -49,4 +50,15 @@ trait StringFieldBehaviours extends FieldBehaviours {
       }
     }
   }
+
+  def fieldWithValidUnicodeChars(form: Form[_],
+                                 fieldName: String): Unit =
+
+    "not bind strings with invalid unicode characters" in {
+
+      invalidUnicodeCharacters.foreach { invalidChar =>
+        val result = form.bind(Map(fieldName -> s"Example text$invalidChar")).apply(fieldName)
+        result.errors must contain only FormError(fieldName, "error.invalidUnicodeChars")
+      }
+    }
 }

--- a/test/forms/letting/PropertyIsNoLongerBeingLetOutFormProviderSpec.scala
+++ b/test/forms/letting/PropertyIsNoLongerBeingLetOutFormProviderSpec.scala
@@ -68,5 +68,10 @@ class PropertyIsNoLongerBeingLetOutFormProviderSpec extends PeriodEndBehaviours 
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/letting/WhatWasTheTypeOfMortgageFormProviderSpec.scala
+++ b/test/forms/letting/WhatWasTheTypeOfMortgageFormProviderSpec.scala
@@ -49,5 +49,10 @@ class WhatWasTheTypeOfMortgageFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/mappings/ConstraintsSpec.scala
+++ b/test/forms/mappings/ConstraintsSpec.scala
@@ -188,4 +188,22 @@ class ConstraintsSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyC
       }
     }
   }
+
+  "validUnicodeCharacters" - {
+
+    "must return Valid if no invalid characters are detected" in {
+      val result = validUnicodeCharacters("Example text")
+      result mustEqual Valid
+    }
+
+    "must return Invalid if the character '\u0002' (start of text, U+0002, 0x2) is detected" in {
+      val result = validUnicodeCharacters("\u0002Example text")
+      result mustEqual Invalid("error.invalidUnicodeChars")
+    }
+
+    "must return Invalid if the character '\u001D' (group separator, U+001D, 0x1d) is detected" in {
+      val result = validUnicodeCharacters("Example\u001Dtext")
+      result mustEqual Invalid("error.invalidUnicodeChars")
+    }
+  }
 }

--- a/test/forms/notification/OtherIncomeOrGainSourceFormProviderSpec.scala
+++ b/test/forms/notification/OtherIncomeOrGainSourceFormProviderSpec.scala
@@ -49,5 +49,10 @@ class OtherIncomeOrGainSourceFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/notification/WhatIsTheIndividualOccupationFormProviderSpec.scala
+++ b/test/forms/notification/WhatIsTheIndividualOccupationFormProviderSpec.scala
@@ -49,5 +49,10 @@ class WhatIsTheIndividualOccupationFormProviderSpec extends StringFieldBehaviour
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/notification/WhatIsTheIndividualsFullNameFormProviderSpec.scala
+++ b/test/forms/notification/WhatIsTheIndividualsFullNameFormProviderSpec.scala
@@ -49,5 +49,10 @@ class WhatIsTheIndividualsFullNameFormProviderSpec extends StringFieldBehaviours
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/notification/WhatIsTheLLPNameFormProviderSpec.scala
+++ b/test/forms/notification/WhatIsTheLLPNameFormProviderSpec.scala
@@ -49,5 +49,10 @@ class WhatIsTheLLPNameFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/notification/WhatIsTheNameOfTheCompanyTheDisclosureWillBeAboutFormProviderSpec.scala
+++ b/test/forms/notification/WhatIsTheNameOfTheCompanyTheDisclosureWillBeAboutFormProviderSpec.scala
@@ -49,5 +49,10 @@ class WhatIsTheNameOfTheCompanyTheDisclosureWillBeAboutFormProviderSpec extends 
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/notification/WhatIsTheNameOfTheOrganisationYouRepresentFormProviderSpec.scala
+++ b/test/forms/notification/WhatIsTheNameOfTheOrganisationYouRepresentFormProviderSpec.scala
@@ -49,5 +49,10 @@ class WhatIsTheNameOfTheOrganisationYouRepresentFormProviderSpec extends StringF
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/notification/WhatIsTheTrustNameFormProviderSpec.scala
+++ b/test/forms/notification/WhatIsTheTrustNameFormProviderSpec.scala
@@ -49,5 +49,10 @@ class WhatIsTheTrustNameFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/notification/WhatIsYourFullNameFormProviderSpec.scala
+++ b/test/forms/notification/WhatIsYourFullNameFormProviderSpec.scala
@@ -49,5 +49,10 @@ class WhatIsYourFullNameFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/notification/WhatIsYourMainOccupationFormProviderSpec.scala
+++ b/test/forms/notification/WhatIsYourMainOccupationFormProviderSpec.scala
@@ -49,5 +49,10 @@ class WhatIsYourMainOccupationFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/notification/WhatWasTheNameOfThePersonWhoDiedFormProviderSpec.scala
+++ b/test/forms/notification/WhatWasTheNameOfThePersonWhoDiedFormProviderSpec.scala
@@ -49,5 +49,10 @@ class WhatWasTheNameOfThePersonWhoDiedFormProviderSpec extends StringFieldBehavi
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/notification/WhatWasThePersonOccupationFormProviderSpec.scala
+++ b/test/forms/notification/WhatWasThePersonOccupationFormProviderSpec.scala
@@ -49,5 +49,10 @@ class WhatWasThePersonOccupationFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/offshore/TaxBeforeFiveYearsFormProviderSpec.scala
+++ b/test/forms/offshore/TaxBeforeFiveYearsFormProviderSpec.scala
@@ -49,5 +49,10 @@ class TaxBeforeFiveYearsFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey, Seq(year))
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/offshore/TaxBeforeNineteenYearsFormProviderSpec.scala
+++ b/test/forms/offshore/TaxBeforeNineteenYearsFormProviderSpec.scala
@@ -50,5 +50,10 @@ class TaxBeforeNineteenYearsFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey, Seq(year))
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/offshore/TaxBeforeSevenYearsFormProviderSpec.scala
+++ b/test/forms/offshore/TaxBeforeSevenYearsFormProviderSpec.scala
@@ -49,5 +49,10 @@ class TaxBeforeSevenYearsFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey, Seq(year))
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/offshore/TaxYearLiabilitiesFormProviderSpec.scala
+++ b/test/forms/offshore/TaxYearLiabilitiesFormProviderSpec.scala
@@ -170,6 +170,43 @@ class TaxYearLiabilitiesFormProviderSpec extends IntFieldBehaviours with BigIntF
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 
+  ".undeclaredIncomeOrGain" - {
+
+    val fieldName = "undeclaredIncomeOrGain"
+    val maxLength = 5000
+
+    val lengthKey = "taxYearLiabilities.undeclaredIncomeOrGain.error.length"
+    val requiredKey = "taxYearLiabilities.undeclaredIncomeOrGain.error.required"
+
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      stringsWithMaxLength(maxLength)
+    )
+
+    behave like fieldWithMaxLength(
+      form,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
+  }
 }

--- a/test/forms/offshore/UnderWhatConsiderationFormProviderSpec.scala
+++ b/test/forms/offshore/UnderWhatConsiderationFormProviderSpec.scala
@@ -49,5 +49,10 @@ class UnderWhatConsiderationFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/offshore/WhatIsYourReasonableExcuseForNotFilingReturnFormProviderSpec.scala
+++ b/test/forms/offshore/WhatIsYourReasonableExcuseForNotFilingReturnFormProviderSpec.scala
@@ -23,28 +23,34 @@ class WhatIsYourReasonableExcuseForNotFilingReturnFormProviderSpec extends Strin
 
   ".reasonableExcuse when entity" - {
 
+    val form = new WhatIsYourReasonableExcuseForNotFilingReturnFormProvider()(true)
     val fieldName = "reasonableExcuse"
     val requiredKey = "whatIsYourReasonableExcuseForNotFilingReturn.error.reasonableExcuse.required"
     val entityLengthKey = "whatIsYourReasonableExcuseForNotFilingReturn.entity.error.reasonableExcuse.length"
     val maxLength = 5000
 
     behave like fieldThatBindsValidData(
-      new WhatIsYourReasonableExcuseForNotFilingReturnFormProvider()(true),
+      form,
       fieldName,
       stringsWithMaxLength(maxLength)
     )
 
     behave like fieldWithMaxLength(
-      new WhatIsYourReasonableExcuseForNotFilingReturnFormProvider()(true),
+      form,
       fieldName,
       maxLength = maxLength,
       lengthError = FormError(fieldName, entityLengthKey, Seq(maxLength))
     )
 
     behave like mandatoryField(
-      new WhatIsYourReasonableExcuseForNotFilingReturnFormProvider()(true),
+      form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
     )
   }
 
@@ -87,6 +93,11 @@ class WhatIsYourReasonableExcuseForNotFilingReturnFormProviderSpec extends Strin
       form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
     )
   }
 }

--- a/test/forms/offshore/WhatIsYourReasonableExcuseFormProviderSpec.scala
+++ b/test/forms/offshore/WhatIsYourReasonableExcuseFormProviderSpec.scala
@@ -47,6 +47,11 @@ class WhatIsYourReasonableExcuseFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 
   ".excuse when agent" - {
@@ -89,6 +94,11 @@ class WhatIsYourReasonableExcuseFormProviderSpec extends StringFieldBehaviours {
       form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
     )
   }
 }

--- a/test/forms/offshore/WhatReasonableCareDidYouTakeFormProviderSpec.scala
+++ b/test/forms/offshore/WhatReasonableCareDidYouTakeFormProviderSpec.scala
@@ -23,28 +23,34 @@ class WhatReasonableCareDidYouTakeFormProviderSpec extends StringFieldBehaviours
 
   ".reasonableCare when entity" - {
 
+    val form = new WhatReasonableCareDidYouTakeFormProvider()(true)
     val fieldName = "reasonableCare"
     val requiredKey = "whatReasonableCareDidYouTake.error.reasonableCare.required"
     val entityLengthKey = "whatReasonableCareDidYouTake.entity.error.reasonableCare.length"
     val maxLength = 5000
 
     behave like fieldThatBindsValidData(
-      new WhatReasonableCareDidYouTakeFormProvider()(true),
+      form,
       fieldName,
       stringsWithMaxLength(maxLength)
     )
 
     behave like fieldWithMaxLength(
-      new WhatReasonableCareDidYouTakeFormProvider()(true),
+      form,
       fieldName,
       maxLength = maxLength,
       lengthError = FormError(fieldName, entityLengthKey, Seq(maxLength))
     )
 
     behave like mandatoryField(
-      new WhatReasonableCareDidYouTakeFormProvider()(true),
+      form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
     )
   }
 
@@ -87,6 +93,11 @@ class WhatReasonableCareDidYouTakeFormProviderSpec extends StringFieldBehaviours
       form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
     )
   }
 }

--- a/test/forms/offshore/YouHaveLeftTheDDSFormProviderSpec.scala
+++ b/test/forms/offshore/YouHaveLeftTheDDSFormProviderSpec.scala
@@ -49,5 +49,10 @@ class YouHaveLeftTheDDSFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/offshore/YouHaveNotIncludedTheTaxYearFormProviderSpec.scala
+++ b/test/forms/offshore/YouHaveNotIncludedTheTaxYearFormProviderSpec.scala
@@ -50,5 +50,10 @@ class YouHaveNotIncludedTheTaxYearFormProviderSpec extends StringFieldBehaviours
       fieldName,
       requiredError = FormError(fieldName, requiredKey, Seq(missingYear))
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/offshore/YouHaveNotSelectedCertainTaxYearFormProviderSpec.scala
+++ b/test/forms/offshore/YouHaveNotSelectedCertainTaxYearFormProviderSpec.scala
@@ -49,5 +49,10 @@ class YouHaveNotSelectedCertainTaxYearFormProviderSpec extends StringFieldBehavi
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/onshore/CorporationTaxLiabilityFormProviderSpec.scala
+++ b/test/forms/onshore/CorporationTaxLiabilityFormProviderSpec.scala
@@ -20,7 +20,8 @@ import java.time.{LocalDate, ZoneOffset}
 import forms.behaviours.{PeriodEndBehaviours, IntFieldBehaviours, BigIntFieldBehaviours, BigDecimalFieldBehaviours, StringFieldBehaviours}
 import play.api.data.FormError
 
-class CorporationTaxLiabilityFormProviderSpec extends PeriodEndBehaviours with IntFieldBehaviours with BigIntFieldBehaviours with BigDecimalFieldBehaviours with StringFieldBehaviours {
+class CorporationTaxLiabilityFormProviderSpec extends PeriodEndBehaviours with IntFieldBehaviours
+  with BigIntFieldBehaviours with BigDecimalFieldBehaviours with StringFieldBehaviours {
 
   val form = new CorporationTaxLiabilityFormProvider()()
 
@@ -145,6 +146,11 @@ class CorporationTaxLiabilityFormProviderSpec extends PeriodEndBehaviours with I
       form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
     )
   }
 }

--- a/test/forms/onshore/DirectorLoanAccountLiabilitiesFormProviderSpec.scala
+++ b/test/forms/onshore/DirectorLoanAccountLiabilitiesFormProviderSpec.scala
@@ -21,7 +21,8 @@ import play.api.data.FormError
 
 import java.time.{LocalDate, ZoneOffset}
 
-class DirectorLoanAccountLiabilitiesFormProviderSpec extends PeriodEndBehaviours with IntFieldBehaviours with BigIntFieldBehaviours with BigDecimalFieldBehaviours with StringFieldBehaviours {
+class DirectorLoanAccountLiabilitiesFormProviderSpec extends PeriodEndBehaviours with IntFieldBehaviours
+  with BigIntFieldBehaviours with BigDecimalFieldBehaviours with StringFieldBehaviours {
 
   val form = new DirectorLoanAccountLiabilitiesFormProvider()()
 
@@ -49,6 +50,11 @@ class DirectorLoanAccountLiabilitiesFormProviderSpec extends PeriodEndBehaviours
       form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
     )
   }
 
@@ -144,6 +150,11 @@ class DirectorLoanAccountLiabilitiesFormProviderSpec extends PeriodEndBehaviours
       form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
     )
   }
 

--- a/test/forms/onshore/NotIncludedMultipleTaxYearsFormProviderSpec.scala
+++ b/test/forms/onshore/NotIncludedMultipleTaxYearsFormProviderSpec.scala
@@ -49,5 +49,10 @@ class NotIncludedMultipleTaxYearsFormProviderSpec extends StringFieldBehaviours 
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/onshore/NotIncludedSingleTaxYearFormProviderSpec.scala
+++ b/test/forms/onshore/NotIncludedSingleTaxYearFormProviderSpec.scala
@@ -50,5 +50,10 @@ class NotIncludedSingleTaxYearFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey, Seq(missingYear))
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/onshore/OnshoreTaxYearLiabilitiesFormProviderSpec.scala
+++ b/test/forms/onshore/OnshoreTaxYearLiabilitiesFormProviderSpec.scala
@@ -20,7 +20,8 @@ import forms.behaviours.{BigIntFieldBehaviours, IntFieldBehaviours, StringFieldB
 import play.api.data.FormError
 import models.WhatOnshoreLiabilitiesDoYouNeedToDisclose
 
-class OnshoreTaxYearLiabilitiesFormProviderSpec extends IntFieldBehaviours with BigIntFieldBehaviours with BigDecimalFieldBehaviours with StringFieldBehaviours {
+class OnshoreTaxYearLiabilitiesFormProviderSpec extends IntFieldBehaviours with BigIntFieldBehaviours
+  with BigDecimalFieldBehaviours with StringFieldBehaviours {
 
   val formWithNoSelections = new OnshoreTaxYearLiabilitiesFormProvider()(Set())
   val formWithNonBusinessSelected = new OnshoreTaxYearLiabilitiesFormProvider()(Set(WhatOnshoreLiabilitiesDoYouNeedToDisclose.NonBusinessIncome))
@@ -170,6 +171,44 @@ class OnshoreTaxYearLiabilitiesFormProviderSpec extends IntFieldBehaviours with 
       formWithNoSelections,
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithValidUnicodeChars(
+      formWithNoSelections,
+      fieldName
+    )
+  }
+
+  ".undeclaredIncomeOrGain" - {
+
+    val fieldName = "undeclaredIncomeOrGain"
+    val maxLength = 5000
+
+    val lengthKey = "onshoreTaxYearLiabilities.undeclaredIncomeOrGain.error.length"
+    val requiredKey = "onshoreTaxYearLiabilities.undeclaredIncomeOrGain.error.required"
+
+    behave like fieldThatBindsValidData(
+      formWithNoSelections,
+      fieldName,
+      stringsWithMaxLength(maxLength)
+    )
+
+    behave like fieldWithMaxLength(
+      formWithNoSelections,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey, Seq(maxLength))
+    )
+
+    behave like mandatoryField(
+      formWithNoSelections,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithValidUnicodeChars(
+      formWithNoSelections,
+      fieldName
     )
   }
 

--- a/test/forms/onshore/ReasonableCareOnshoreFormProviderSpec.scala
+++ b/test/forms/onshore/ReasonableCareOnshoreFormProviderSpec.scala
@@ -23,28 +23,34 @@ class ReasonableCareOnshoreFormProviderSpec extends StringFieldBehaviours {
 
   ".reasonableCare when entity" - {
 
+    val form = new ReasonableCareOnshoreFormProvider()(true)
     val fieldName = "reasonableCare"
     val requiredKey = "whatReasonableCareDidYouTake.error.reasonableCare.required"
     val entityLengthKey = "whatReasonableCareDidYouTake.entity.error.reasonableCare.length"
     val maxLength = 5000
 
     behave like fieldThatBindsValidData(
-      new ReasonableCareOnshoreFormProvider()(true),
+      form,
       fieldName,
       stringsWithMaxLength(maxLength)
     )
 
     behave like fieldWithMaxLength(
-      new ReasonableCareOnshoreFormProvider()(true),
+      form,
       fieldName,
       maxLength = maxLength,
       lengthError = FormError(fieldName, entityLengthKey, Seq(maxLength))
     )
 
     behave like mandatoryField(
-      new ReasonableCareOnshoreFormProvider()(true),
+      form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
     )
   }
 
@@ -87,6 +93,11 @@ class ReasonableCareOnshoreFormProviderSpec extends StringFieldBehaviours {
       form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
     )
   }
 }

--- a/test/forms/onshore/ReasonableExcuseForNotFilingOnshoreFormProviderSpec.scala
+++ b/test/forms/onshore/ReasonableExcuseForNotFilingOnshoreFormProviderSpec.scala
@@ -23,28 +23,34 @@ class ReasonableExcuseForNotFilingOnshoreFormProviderSpec extends StringFieldBeh
 
   ".reasonableExcuse when entity" - {
 
+    val form = new ReasonableExcuseForNotFilingOnshoreFormProvider()(true)
     val fieldName = "reasonableExcuse"
     val requiredKey = "whatIsYourReasonableExcuseForNotFilingReturn.error.reasonableExcuse.required"
     val entityLengthKey = "whatIsYourReasonableExcuseForNotFilingReturn.entity.error.reasonableExcuse.length"
     val maxLength = 5000
 
     behave like fieldThatBindsValidData(
-      new ReasonableExcuseForNotFilingOnshoreFormProvider()(true),
+      form,
       fieldName,
       stringsWithMaxLength(maxLength)
     )
 
     behave like fieldWithMaxLength(
-      new ReasonableExcuseForNotFilingOnshoreFormProvider()(true),
+      form,
       fieldName,
       maxLength = maxLength,
       lengthError = FormError(fieldName, entityLengthKey, Seq(maxLength))
     )
 
     behave like mandatoryField(
-      new ReasonableExcuseForNotFilingOnshoreFormProvider()(true),
+      form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
     )
   }
 
@@ -87,6 +93,11 @@ class ReasonableExcuseForNotFilingOnshoreFormProviderSpec extends StringFieldBeh
       form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
     )
   }
 }

--- a/test/forms/onshore/ReasonableExcuseOnshoreFormProviderSpec.scala
+++ b/test/forms/onshore/ReasonableExcuseOnshoreFormProviderSpec.scala
@@ -47,6 +47,11 @@ class ReasonableExcuseOnshoreFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 
   ".excuse when agent" - {
@@ -89,6 +94,11 @@ class ReasonableExcuseOnshoreFormProviderSpec extends StringFieldBehaviours {
       form,
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
     )
   }
 }

--- a/test/forms/onshore/TaxBeforeFiveYearsOnshoreFormProviderSpec.scala
+++ b/test/forms/onshore/TaxBeforeFiveYearsOnshoreFormProviderSpec.scala
@@ -49,5 +49,10 @@ class TaxBeforeFiveYearsOnshoreFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey, Seq(year))
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/onshore/TaxBeforeNineteenYearsOnshoreFormProviderSpec.scala
+++ b/test/forms/onshore/TaxBeforeNineteenYearsOnshoreFormProviderSpec.scala
@@ -50,5 +50,10 @@ class TaxBeforeNineteenYearsOnshoreFormProviderSpec extends StringFieldBehaviour
       fieldName,
       requiredError = FormError(fieldName, requiredKey, Seq(year))
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/onshore/TaxBeforeThreeYearsOnshoreFormProviderSpec.scala
+++ b/test/forms/onshore/TaxBeforeThreeYearsOnshoreFormProviderSpec.scala
@@ -49,5 +49,10 @@ class TaxBeforeThreeYearsOnshoreFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey, Seq(year))
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/onshore/WhichLandlordAssociationsAreYouAMemberOfFormProviderSpec.scala
+++ b/test/forms/onshore/WhichLandlordAssociationsAreYouAMemberOfFormProviderSpec.scala
@@ -49,5 +49,10 @@ class WhichLandlordAssociationsAreYouAMemberOfFormProviderSpec extends StringFie
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/onshore/YouHaveLeftTheDDSOnshoreFormProviderSpec.scala
+++ b/test/forms/onshore/YouHaveLeftTheDDSOnshoreFormProviderSpec.scala
@@ -49,5 +49,10 @@ class YouHaveLeftTheDDSOnshoreFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/otherLiabilities/DescribeTheGiftFormProviderSpec.scala
+++ b/test/forms/otherLiabilities/DescribeTheGiftFormProviderSpec.scala
@@ -49,5 +49,10 @@ class DescribeTheGiftFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/otherLiabilities/WhatOtherLiabilityIssuesFormProviderSpec.scala
+++ b/test/forms/otherLiabilities/WhatOtherLiabilityIssuesFormProviderSpec.scala
@@ -49,5 +49,10 @@ class WhatOtherLiabilityIssuesFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/reason/AdviceBusinessNameFormProviderSpec.scala
+++ b/test/forms/reason/AdviceBusinessNameFormProviderSpec.scala
@@ -49,5 +49,10 @@ class AdviceBusinessNameFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/reason/AdviceGivenFormProviderSpec.scala
+++ b/test/forms/reason/AdviceGivenFormProviderSpec.scala
@@ -50,6 +50,11 @@ class AdviceGivenFormProviderSpec extends OptionFieldBehaviours with StringField
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 
   

--- a/test/forms/reason/AdviceProfessionFormProviderSpec.scala
+++ b/test/forms/reason/AdviceProfessionFormProviderSpec.scala
@@ -57,5 +57,10 @@ class AdviceProfessionFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/reason/PersonWhoGaveAdviceFormProviderSpec.scala
+++ b/test/forms/reason/PersonWhoGaveAdviceFormProviderSpec.scala
@@ -49,5 +49,10 @@ class PersonWhoGaveAdviceFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/reason/WhatIsTheReasonForMakingADisclosureNowFormProviderSpec.scala
+++ b/test/forms/reason/WhatIsTheReasonForMakingADisclosureNowFormProviderSpec.scala
@@ -49,5 +49,10 @@ class WhatIsTheReasonForMakingADisclosureNowFormProviderSpec extends StringField
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }

--- a/test/forms/reason/WhyNotBeforeNowFormProviderSpec.scala
+++ b/test/forms/reason/WhyNotBeforeNowFormProviderSpec.scala
@@ -49,5 +49,10 @@ class WhyNotBeforeNowFormProviderSpec extends StringFieldBehaviours {
       fieldName,
       requiredError = FormError(fieldName, requiredKey)
     )
+
+    behave like fieldWithValidUnicodeChars(
+      form,
+      fieldName
+    )
   }
 }


### PR DESCRIPTION
The two characters that are blocked are:

- Start of text, U+0002, 0x02, ``
- Group separator, U+001D, 0x1d, ``

These are the only ones I can see in the logs/alerts history. The validation has been added to every text field that didn't already have some associated format or regex.